### PR TITLE
support for multiple suites defined using the suite-file tag in testng xml files

### DIFF
--- a/modules/clients/java-client/src/main/java/com/redhat/reportengine/client/JulReportEngineLogHandler.java
+++ b/modules/clients/java-client/src/main/java/com/redhat/reportengine/client/JulReportEngineLogHandler.java
@@ -37,6 +37,8 @@ public class JulReportEngineLogHandler extends Handler {
 		try {
 			remoteApi.insertLogMessage(testLogs);
 		} catch (Exception ex) {
+			LogHandler.teardown();
+			System.out.println("error writing log to report engine; removing appender;");
 			ex.printStackTrace();
 		}
 	}

--- a/modules/clients/java-client/src/main/java/com/redhat/reportengine/client/RemoteAPI.java
+++ b/modules/clients/java-client/src/main/java/com/redhat/reportengine/client/RemoteAPI.java
@@ -37,11 +37,21 @@ import com.redhat.reportengine.restapi.urimap.TestResultsRestUriMap;
  * Mar 16, 2012
  */
 public class RemoteAPI {
+	
+	static RemoteAPI INSTANCE;
+	
+	public static synchronized RemoteAPI getRemoteApi(){
+		if(INSTANCE == null){
+			INSTANCE = new RemoteAPI();
+		}
+		return INSTANCE;
+		
+	}
 	protected static final Logger _logger = Logger.getLogger(RemoteAPI.class.getName());
 	ClientCommon test = new ClientCommon();
-	protected static boolean initialized = false;
-	private static boolean clientConfigurationSuccess = false;
-	private static boolean clientLoadedSuccess = false;
+	protected boolean initialized = false;
+	private boolean clientConfigurationSuccess = false;
+	private boolean clientLoadedSuccess = false;
 
 	private static final String rePropertyFile 		= "REPORT_ENGINE_PROPERTY_FILE";	
 	private static final String originalFile 		= "ORIGINAL.FILE";
@@ -61,7 +71,7 @@ public class RemoteAPI {
 			"com.sun.jersey," +
 			"org.jboss.resteasy";
 
-	private RESTClientRestEasy restClient = null;
+	protected RESTClientRestEasy restClient = null;
 
 	public RemoteAPI() {
 		super();
@@ -227,7 +237,7 @@ public class RemoteAPI {
 			_logger.log(Level.INFO, "Report Engine Server Time: "+getServerTime());
 			this.insertTestSuite(testSuiteName, comments);
 			_logger.log(Level.INFO, "Report Engine Client Loaded successfully...");		
-			RemoteAPI.setClientLoadedSuccess(true);
+			setClientLoadedSuccess(true);
 		}else{
 			_logger.log(Level.WARNING, "Report Engine Client Failed to Load..");
 		}		
@@ -274,6 +284,8 @@ public class RemoteAPI {
 	public void updateTestSuite(String status, String build) throws Exception{
 		updateTestSuite(status, build, null);
 	}
+	
+	
 	public void updateTestSuite(String status, String build, String comments) throws Exception{
 		TestSuite testSuite = new TestSuite();
 		testSuite.setId(test.getTestSuiteId());
@@ -387,6 +399,10 @@ public class RemoteAPI {
 	public String getLogLevel(){
 		return test.getLogLevel();
 	}
+	public void removeHandlers(){
+		LogHandler.teardown();
+		
+	}
 
 	/**
 	 * @return the clientConfigurationSuccess
@@ -399,20 +415,20 @@ public class RemoteAPI {
 	 * @param clientConfigurationSuccess the clientConfigurationSuccess to set
 	 */
 	public void setClientConfigurationSuccess(boolean clientConfigurationSuccess) {
-		RemoteAPI.clientConfigurationSuccess = clientConfigurationSuccess;
+		this.clientConfigurationSuccess = clientConfigurationSuccess;
 	}
 
 	/**
 	 * @return the clientLoadedSuccess
 	 */
-	public static boolean isClientLoadedSuccess() {
+	public boolean isClientLoadedSuccess() {
 		return clientLoadedSuccess;
 	}
 
 	/**
 	 * @param clientLoadedSuccess the clientLoadedSuccess to set
 	 */
-	public static void setClientLoadedSuccess(boolean clientLoadedSuccess) {
-		RemoteAPI.clientLoadedSuccess = clientLoadedSuccess;
+	public void setClientLoadedSuccess(boolean clientLoadedSuccess) {
+		this.clientLoadedSuccess = clientLoadedSuccess;
 	}
 }

--- a/modules/clients/java-client/src/main/java/com/redhat/reportengine/client/RemoteEngineMultiInstanceClientTestNGListener.java
+++ b/modules/clients/java-client/src/main/java/com/redhat/reportengine/client/RemoteEngineMultiInstanceClientTestNGListener.java
@@ -1,0 +1,47 @@
+package com.redhat.reportengine.client;
+
+import java.net.InetAddress;
+import java.util.logging.Level;
+
+import org.testng.ISuite;
+
+public class RemoteEngineMultiInstanceClientTestNGListener extends ReportEngineClientTestNGListener{
+
+	private RemoteAPI remoteApi;
+	private String currentSuiteFile;
+
+	public RemoteEngineMultiInstanceClientTestNGListener(){
+		super(false); //donothign constructor
+	}
+
+	@Override
+	protected RemoteAPI getRemoteApi() {
+		return remoteApi;
+	}
+	
+	@Override
+	public void onStart(ISuite suite) {
+		restartRemoteApiOnSuiteChange(suite);
+		super.onStart(suite);
+	}
+	
+	
+	private void restartRemoteApiOnSuiteChange(ISuite arg0){
+		if (!arg0.getXmlSuite().getFileName().equals(currentSuiteFile)) {
+			_logger.log(Level.WARNING, arg0.getXmlSuite().getFileName());
+			startRemoteApi();
+			currentSuiteFile = arg0.getXmlSuite().getFileName();
+		}
+	}
+	
+	private void startRemoteApi(){
+		remoteApi = new RemoteAPI();
+		try {
+			_logger.log(Level.INFO, "Starting Report Engine Client");
+			remoteApi.initClient(InetAddress.getLocalHost().getHostName()+" ["+InetAddress.getLocalHost().getHostAddress()+"]");
+		} catch (Exception ex) {
+			_logger.log(Level.SEVERE, "Report Engine Client Failed to start!!", ex);
+		}
+		
+	}
+}

--- a/modules/clients/java-client/src/main/java/com/redhat/reportengine/client/ReportEngineClientJunitListener.java
+++ b/modules/clients/java-client/src/main/java/com/redhat/reportengine/client/ReportEngineClientJunitListener.java
@@ -18,11 +18,10 @@ import com.redhat.reportengine.server.dbmap.TestSuite;
  */
 public class ReportEngineClientJunitListener extends RunListener{
 	protected static Logger _logger = Logger.getLogger(ReportEngineClientJunitListener.class.getName());
-	private static RemoteAPI reportEngineClientAPI = new RemoteAPI();
 
 	public ReportEngineClientJunitListener() {
 		try {
-			reportEngineClientAPI.initClient(InetAddress.getLocalHost().getHostName()+" ["+InetAddress.getLocalHost().getHostAddress()+"]");
+			getRemoteApi().initClient(InetAddress.getLocalHost().getHostName()+" ["+InetAddress.getLocalHost().getHostAddress()+"]");
 		} catch (Exception ex) {
 			_logger.log(Level.SEVERE, "Report Engine Client Failed to start!!", ex);
 		}
@@ -32,16 +31,16 @@ public class ReportEngineClientJunitListener extends RunListener{
 	 * Will be called before any tests have been run. 
 	 * */
 	public void testRunStarted(Description description){
-		if(RemoteAPI.isClientLoadedSuccess()){
-			reportEngineClientAPI.runLogHandler();
+		if(getRemoteApi().isClientLoadedSuccess()){
+			getRemoteApi().runLogHandler();
 			try {
 				if(description != null){
 					if(description.getDisplayName() != null){
-						reportEngineClientAPI.updateTestSuiteName(description.getDisplayName());
+						getRemoteApi().updateTestSuiteName(description.getDisplayName());
 						return;
 					}
 				}
-				reportEngineClientAPI.insertTestGroup("Junit - No groups");
+				getRemoteApi().insertTestGroup("Junit - No groups");
 			} catch (Exception ex) {
 				_logger.log(Level.SEVERE, "Error on testRunStarted,", ex);
 			}
@@ -49,12 +48,19 @@ public class ReportEngineClientJunitListener extends RunListener{
 	}
 
 	/**
+	 * @return
+	 */
+	private RemoteAPI getRemoteApi() {
+		return RemoteAPI.getRemoteApi();
+	}
+
+	/**
 	 *  Will be called when all tests have finished 
 	 * */
 	public void testRunFinished(Result result) {
-		if(RemoteAPI.isClientLoadedSuccess()){
+		if(getRemoteApi().isClientLoadedSuccess()){
 			try {
-				reportEngineClientAPI.updateTestSuite(TestSuite.COMPLETED, System.getProperty(reportEngineClientAPI.getBuildVersionReference()));
+				getRemoteApi().updateTestSuite(TestSuite.COMPLETED, System.getProperty(getRemoteApi().getBuildVersionReference()));
 			} catch (Exception ex) {
 				_logger.log(Level.SEVERE, "Error on testRunFinished,", ex);
 			}	
@@ -65,9 +71,9 @@ public class ReportEngineClientJunitListener extends RunListener{
 	 *  Will be called when an atomic test is about to be started. 
 	 * */
 	public void testStarted(Description description) {
-		if(RemoteAPI.isClientLoadedSuccess()){
+		if(getRemoteApi().isClientLoadedSuccess()){
 			try {
-				reportEngineClientAPI.insertTestCase(description.getMethodName(), description.getClassName()+"."+description.getMethodName(), TestCase.RUNNING);
+				getRemoteApi().insertTestCase(description.getMethodName(), description.getClassName()+"."+description.getMethodName(), TestCase.RUNNING);
 			} catch (Exception ex) {
 				_logger.log(Level.SEVERE, "Error on testStarted,", ex);
 			}
@@ -78,9 +84,9 @@ public class ReportEngineClientJunitListener extends RunListener{
 	 *  Will be called when an atomic test has finished, whether the test succeeds or fails. 
 	 * */
 	public void testFinished(Description description) {
-		if(RemoteAPI.isClientLoadedSuccess()){
+		if(getRemoteApi().isClientLoadedSuccess()){
 			try {
-				reportEngineClientAPI.updateTestCase(TestCase.PASSED);
+				getRemoteApi().updateTestCase(TestCase.PASSED);
 			} catch (Exception ex) {
 				_logger.log(Level.SEVERE, "Error on testFinished,", ex);
 			}
@@ -91,10 +97,10 @@ public class ReportEngineClientJunitListener extends RunListener{
 	 *  Will be called when an atomic test fails. 
 	 * */
 	public void testFailure(Failure failure) {
-		if(RemoteAPI.isClientLoadedSuccess()){
+		if(getRemoteApi().isClientLoadedSuccess()){
 			try {
-				reportEngineClientAPI.takeScreenShot();
-				reportEngineClientAPI.updateTestCase(TestCase.FAILED, ClientCommon.toString(failure.getException()));
+				getRemoteApi().takeScreenShot();
+				getRemoteApi().updateTestCase(TestCase.FAILED, ClientCommon.toString(failure.getException()));
 			} catch (Exception ex) {
 				_logger.log(Level.SEVERE, "Error on testFailure,", ex);
 			}
@@ -105,12 +111,12 @@ public class ReportEngineClientJunitListener extends RunListener{
 	 *  Will be called when a test will not be run, generally because a test method is annotated with Ignore. 
 	 * */
 	public void testIgnored(Description description) {
-		if(RemoteAPI.isClientLoadedSuccess()){
+		if(getRemoteApi().isClientLoadedSuccess()){
 			try {
-				if(reportEngineClientAPI.isLastTestStateRunning()){
-					reportEngineClientAPI.updateTestCase(TestCase.SKIPPED);
+				if(getRemoteApi().isLastTestStateRunning()){
+					getRemoteApi().updateTestCase(TestCase.SKIPPED);
 				}else{
-					reportEngineClientAPI.insertTestCase(description.getMethodName(), description.getClassName()+"."+description.getMethodName(), TestCase.SKIPPED);
+					getRemoteApi().insertTestCase(description.getMethodName(), description.getClassName()+"."+description.getMethodName(), TestCase.SKIPPED);
 				}
 			} catch (Exception ex) {
 				_logger.log(Level.SEVERE, "Error on testIgnored,", ex);

--- a/modules/clients/java-client/src/main/java/com/redhat/reportengine/client/ReportEngineClientTestNGListener.java
+++ b/modules/clients/java-client/src/main/java/com/redhat/reportengine/client/ReportEngineClientTestNGListener.java
@@ -23,14 +23,22 @@ import com.redhat.reportengine.server.dbmap.TestSuite;
  */
 public class ReportEngineClientTestNGListener implements IResultListener, ISuiteListener {
 	protected static Logger _logger = Logger.getLogger(ReportEngineClientTestNGListener.class.getName());
-	private static RemoteAPI reportEngine = new RemoteAPI();
+
+	public ReportEngineClientTestNGListener(boolean donothing){
+		//donothing
+
+	}
 
 	public ReportEngineClientTestNGListener(){
 		try {
-			reportEngine.initClient(InetAddress.getLocalHost().getHostName()+" ["+InetAddress.getLocalHost().getHostAddress()+"]");
+			RemoteAPI.getRemoteApi().initClient(InetAddress.getLocalHost().getHostName()+" ["+InetAddress.getLocalHost().getHostAddress()+"]");
 		} catch (Exception ex) {
 			_logger.log(Level.SEVERE, "Report Engine Client Failed to start!!", ex);
 		}
+	}
+
+	protected RemoteAPI getRemoteApi(){
+		return RemoteAPI.getRemoteApi();
 	}
 	
 	public String getParametersString(Object[] parameters) {
@@ -46,7 +54,7 @@ public class ReportEngineClientTestNGListener implements IResultListener, ISuite
 	 */
 	@Override
 	public void onFinish(ITestContext context) {
-		if(RemoteAPI.isClientLoadedSuccess()){
+		if(getRemoteApi().isClientLoadedSuccess()){
 			
 		}
 		
@@ -58,9 +66,9 @@ public class ReportEngineClientTestNGListener implements IResultListener, ISuite
 	@Override
 	public void onStart(ITestContext context) {
 		// Test Group
-		if(RemoteAPI.isClientLoadedSuccess()){
+		if(getRemoteApi().isClientLoadedSuccess()){
 			try {
-				reportEngine.insertTestGroup(context.getName());
+				getRemoteApi().insertTestGroup(context.getName());
 			} catch (Exception ex) {
 				_logger.log(Level.SEVERE, "Error on onStart,", ex);
 			}
@@ -80,10 +88,10 @@ public class ReportEngineClientTestNGListener implements IResultListener, ISuite
 	 */
 	@Override
 	public void onTestFailure(ITestResult result) {
-		if(RemoteAPI.isClientLoadedSuccess()){
+		if(getRemoteApi().isClientLoadedSuccess()){
 			try {
-				reportEngine.takeScreenShot();
-				reportEngine.updateTestCase(TestCase.FAILED, ClientCommon.toString(result.getThrowable()));
+				getRemoteApi().takeScreenShot();
+				getRemoteApi().updateTestCase(TestCase.FAILED, ClientCommon.toString(result.getThrowable()));
 			} catch (Exception ex) {
 				_logger.log(Level.SEVERE, "Error on onTestFailure,", ex);
 			}
@@ -95,12 +103,12 @@ public class ReportEngineClientTestNGListener implements IResultListener, ISuite
 	 */
 	@Override
 	public void onTestSkipped(ITestResult result) {
-		if(RemoteAPI.isClientLoadedSuccess()){
+		if(getRemoteApi().isClientLoadedSuccess()){
 			try {
-				if(reportEngine.isLastTestStateRunning()){
-					reportEngine.updateTestCase(TestCase.SKIPPED);
+				if(getRemoteApi().isLastTestStateRunning()){
+					getRemoteApi().updateTestCase(TestCase.SKIPPED);
 				}else{
-					reportEngine.insertTestCase(result.getName(), result.getName()+"("+getParametersString(result.getParameters())+")", TestCase.SKIPPED);
+					getRemoteApi().insertTestCase(result.getName(), result.getName()+"("+getParametersString(result.getParameters())+")", TestCase.SKIPPED);
 				}
 			} catch (Exception ex) {
 				_logger.log(Level.SEVERE, "Error on onTestSkipped,", ex);
@@ -114,9 +122,9 @@ public class ReportEngineClientTestNGListener implements IResultListener, ISuite
 	 */
 	@Override
 	public void onTestStart(ITestResult test) {
-		if(RemoteAPI.isClientLoadedSuccess()){
+		if(getRemoteApi().isClientLoadedSuccess()){
 			try {
-				reportEngine.insertTestCase(test.getName(), test.getName()+"("+getParametersString(test.getParameters())+")", TestCase.RUNNING);
+				getRemoteApi().insertTestCase(test.getName(), test.getName()+"("+getParametersString(test.getParameters())+")", TestCase.RUNNING);
 			} catch (Exception ex) {
 				_logger.log(Level.SEVERE, "Error on onTestStart,", ex);
 			}
@@ -128,9 +136,9 @@ public class ReportEngineClientTestNGListener implements IResultListener, ISuite
 	 */
 	@Override
 	public void onTestSuccess(ITestResult result) {
-		if(RemoteAPI.isClientLoadedSuccess()){
+		if(getRemoteApi().isClientLoadedSuccess()){
 			try {
-				reportEngine.updateTestCase(TestCase.PASSED);
+				getRemoteApi().updateTestCase(TestCase.PASSED);
 			} catch (Exception ex) {
 				_logger.log(Level.SEVERE, "Error on onTestSuccess,", ex);
 			}
@@ -142,7 +150,7 @@ public class ReportEngineClientTestNGListener implements IResultListener, ISuite
 	 */
 	@Override
 	public void onConfigurationFailure(ITestResult testResult) {
-		if(RemoteAPI.isClientLoadedSuccess()){
+		if(getRemoteApi().isClientLoadedSuccess()){
 			if(testResult.getThrowable() == null){
 				_logger.log(Level.WARNING, "Configuration Failed!!");
 			}else{
@@ -156,7 +164,7 @@ public class ReportEngineClientTestNGListener implements IResultListener, ISuite
 	 */
 	@Override
 	public void onConfigurationSkip(ITestResult testResult) {
-		if(RemoteAPI.isClientLoadedSuccess()){
+		if(getRemoteApi().isClientLoadedSuccess()){
 			if(testResult.getThrowable() == null){
 				_logger.log(Level.WARNING, "Configuration Skipped!!");
 			}else{
@@ -170,7 +178,7 @@ public class ReportEngineClientTestNGListener implements IResultListener, ISuite
 	 */
 	@Override
 	public void onConfigurationSuccess(ITestResult testResult) {
-		if(RemoteAPI.isClientLoadedSuccess()){
+		if(getRemoteApi().isClientLoadedSuccess()){
 			_logger.log(Level.FINE, "Configuration loadded Successfully!!");
 		}		
 	}
@@ -180,12 +188,13 @@ public class ReportEngineClientTestNGListener implements IResultListener, ISuite
 	 */
 	@Override
 	public void onFinish(ISuite suite) {
-		if(RemoteAPI.isClientLoadedSuccess()){
+		if(getRemoteApi().isClientLoadedSuccess()){
 			try {
-				reportEngine.updateTestSuite(TestSuite.COMPLETED, System.getProperty(reportEngine.getBuildVersionReference()));
+				getRemoteApi().updateTestSuite(TestSuite.COMPLETED, System.getProperty(getRemoteApi().getBuildVersionReference()));
 			} catch (Exception ex) {
 				_logger.log(Level.SEVERE, "Error on onFinish,", ex);
 			}	
+			getRemoteApi().removeHandlers();
 		}	
 	}
 
@@ -194,10 +203,10 @@ public class ReportEngineClientTestNGListener implements IResultListener, ISuite
 	 */
 	@Override
 	public void onStart(ISuite suite) {
-		if(RemoteAPI.isClientLoadedSuccess()){
+		if(getRemoteApi().isClientLoadedSuccess()){
 			try {
-				reportEngine.runLogHandler();
-				reportEngine.updateTestSuiteName(suite.getName());				
+				getRemoteApi().runLogHandler();
+				getRemoteApi().updateTestSuiteName(suite.getName());				
 			} catch (Exception ex) {
 				_logger.log(Level.SEVERE, "Error on onStart,", ex);
 			}	


### PR DESCRIPTION
- All Listeners uses remote APi as a singleton
- for the support of multiple suite-files, ReportEngineMultiInstanceClientTestNGListener created
